### PR TITLE
Migrate to GradleMavenPush https://github.com/Vorlonsoft/GradleMavenPush

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -10,4 +10,4 @@ android {
   }
 }
 
-//apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'
+//apply from: 'https://raw.github.com/Vorlonsoft/GradleMavenPush/master/maven-push.gradle'

--- a/library/gradle.properties
+++ b/library/gradle.properties
@@ -4,18 +4,13 @@ GROUP=com.jaredrummler
 
 POM_NAME=APK Parser
 POM_ARTIFACT_ID=apk-parser
-POM_PACKAGING=aar
 
 POM_DESCRIPTION=APK parser for Android
 POM_URL=https://github.com/jaredrummler/APKParser
 POM_SCM_URL=https://github.com/jaredrummler/APKParser.git
 POM_SCM_CONNECTION=scm:git@github.com:jaredrummler/apk-parser.git
-POM_SCM_DEV_CONNECTION=scm:git@github.com:jaredrummler/apk-parser.git
 POM_LICENCE_NAME=The BSD 3-Clause License
 POM_LICENCE_URL=https://raw.githubusercontent.com/jaredrummler/apk-parser/master/LICENSE.txt
-POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=jaredrummler
 POM_DEVELOPER_NAME=Jared Rummler
-
-SNAPSHOT_REPOSITORY_URL=https://oss.sonatype.org/content/repositories/snapshots
-RELEASE_REPOSITORY_URL=https://oss.sonatype.org/service/local/staging/deploy/maven2
+POM_DEVELOPER_EMAIL=jared.rummler@gmail.com


### PR DESCRIPTION
Migrate to GradleMavenPush https://github.com/Vorlonsoft/GradleMavenPush

Reasons: 
- Old plugin don't have updates for 4 years
- Better javadocs generation
- Better pom file generation
- Smaller gradle.properties
- You can easy migrate from Maven Central to JCenter by adding to your code `IS_JCENTER = true` only and register at https://bintray.com/bintray/jcenter